### PR TITLE
Update Discord invite link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -143,7 +143,7 @@ export default function Home() {
                   target="_blank"
                   rel="noopener"
                   className="underline"
-                  href="https://discord.gg/FRTFgFX6mu"
+                  href="https://discord.gg/Up2QGbMKHY"
                 >
                   Join our discord!
                 </a>


### PR DESCRIPTION
This PR updates the Discord invite link on the website. It fixes [this issue](https://github.com/GamestonkTerminal/GamestonkTerminal/issues/723).